### PR TITLE
Handle integer replies, implement a connect timeout and dynamic config in VCL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ So far the module builds and runs on FreeBSD--on other platforms, you are on you
 Functions and procedures
 ------------------------
 
+*redis.init_redis(host, port, timeout_ms)*
+
+Use the redis server at the given _host_ and _port_ with a timeout
+of _timeout__ms_ milliseconds.
+If _port_ is less than or equal to zero, the default port of 6379 is used.
+If _timeout__ms_ is less than or equal to zero, a default timeout of 200ms is used.
+
+This function is supposed to be called from the Varnish subroutine _vcl__init_.
+If the call is left out, the module will attempt to connect to the Redis server
+at 127.0.0.1:6379 with a connect timeout of 200ms.
+
 *redis.send(command)*
 
 Sends the given _command_ to redis; the response will be ignored.

--- a/examples/example.vcl
+++ b/examples/example.vcl
@@ -22,7 +22,7 @@ backend be1 {
 
 sub vcl_recv {
   #
-  # redis.call is a procedure, it will send the command to redis and ignore
+  # redis.send is a procedure, it will send the command to redis and ignore
   # the response. If the command errors out, it will be logged but the VCL
   # will not know.
   #

--- a/examples/example.vcl
+++ b/examples/example.vcl
@@ -9,6 +9,17 @@ backend be1 {
   .port = "80";
 }
 
+#sub vcl_init {
+  #
+  # By default, the redis module will attempt to connect to a Redis server
+  # at 127.0.0.1:6379 with a connect timeout of 200 milliseconds.
+  #
+  # The function redis.init_redis(host, port, timeout_ms) may be used to
+  # connect to an alternate Redis server or use a different connect timeout.
+  #
+  # redis.init_redis("localhost", 6379, 200);  /* default values */
+#}
+
 sub vcl_recv {
   #
   # redis.call is a procedure, it will send the command to redis and ignore

--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -114,6 +114,7 @@ vmod_call(struct sess *sp, struct vmod_priv *priv, const char *command)
 {
 	redisReply *reply = NULL;
 	const char *ret = NULL;
+	char *digits;
 
 	reply = redis_common(sp, priv, command);
 	if (reply == NULL) {
@@ -128,7 +129,10 @@ vmod_call(struct sess *sp, struct vmod_priv *priv, const char *command)
 		ret = strdup(reply->str);
 		break;
 	case REDIS_REPLY_INTEGER:
-		ret = strdup("integer");	/* FIXME */
+		digits = malloc(21); /* sizeof(long long) == 8; 20 digits + NUL */
+		if(digits)
+			sprintf(digits, "%lld", reply->integer);
+		ret = digits;
 		break;
 	case REDIS_REPLY_NIL:
 		ret = NULL;

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -1,4 +1,5 @@
 Module redis
 Init init_function
+Function VOID init_redis(PRIV_VCL, STRING, INT, INT)
 Function VOID send(PRIV_VCL, STRING)
 Function STRING call(PRIV_VCL, STRING)

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -1,4 +1,4 @@
 Module redis
 Init init_function
-Function VOID send(PRIV_CALL, STRING)
-Function STRING call(PRIV_CALL, STRING)
+Function VOID send(PRIV_VCL, STRING)
+Function STRING call(PRIV_VCL, STRING)


### PR DESCRIPTION
Hi,

Please consider pulling the following patches (details available in the commit messages):
Noah Williamsson (6):
      Handle REDIS_REPLY_INTEGER in vmod_call() and return it as a string
      Initialize config (host, port) once per VCL instead of once every call
      Implement a connect timeout for connecting to Redis, defaulting to 200ms
      Allow the Redis server and timeout to be set in VCL via redis.init_redis()
      Provide a commented out example of redis.init_redis() in examples/example.vcl
      Fix typo in examples/example.vcl (redis.call -> redis.send)

Tested on 32- and 64-bit Linux aswell as Mac OS X with Varnish 3.0.2.
